### PR TITLE
feat: 쿠폰 발급로직 구현 테스트 중 오류 발견/#1 feat 

### DIFF
--- a/api/src/test/java/com/example/api/service/ApplyServiceTest.java
+++ b/api/src/test/java/com/example/api/service/ApplyServiceTest.java
@@ -4,6 +4,10 @@ import com.example.api.repository.CouponRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
@@ -24,5 +28,30 @@ public class ApplyServiceTest {
         assertThat(count).isEqualTo(1);
     }
 
+    @Test
+    public void 여러명응모() throws InterruptedException {
+        int threadCount = 1000;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
 
+        for (int i = 0; i < threadCount; i++) {
+            long userId = i;
+            executorService.submit(() ->{
+                try {
+                    applyService.apply(userId);
+                } finally {
+                    latch.countDown();
+                }
+            });
+
+        }
+
+        latch.await();
+
+        long count = couponRepository.count();
+
+        assertThat(count).isEqualTo(100);
+
+
+    }
 }


### PR DESCRIPTION
## 기능 구현쿠폰 테스트 여러명 실행시 테스트시 오류 발생

<img width="239" height="92" alt="image" src="https://github.com/user-attachments/assets/f8e72801-04b4-4f49-8a0e-1c2b80e50dd2" />

이유: race condition 발생 (2개이상의 쓰레드가 공유데이터에 access 해서)
- 99에서 2개이상의  쓰레드 동시 접근해서 100이 넘어감