### PR TITLE
feat: 쿠폰 생성 로직에 redis의 incr를 사용하여 동시성 문제 해결/#2

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -18,6 +18,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/api/src/main/java/com/example/api/repository/CouponCountRepository.java
+++ b/api/src/main/java/com/example/api/repository/CouponCountRepository.java
@@ -1,0 +1,20 @@
+package com.example.api.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CouponCountRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public CouponCountRepository(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public Long increment() {
+        return redisTemplate
+                .opsForValue()
+                .increment("coupon_count");
+    }
+}

--- a/api/src/main/java/com/example/api/service/ApplyService.java
+++ b/api/src/main/java/com/example/api/service/ApplyService.java
@@ -1,6 +1,7 @@
 package com.example.api.service;
 
 import com.example.api.domain.Coupon;
+import com.example.api.repository.CouponCountRepository;
 import com.example.api.repository.CouponRepository;
 import org.springframework.stereotype.Service;
 
@@ -9,12 +10,19 @@ public class ApplyService {
 
     private final CouponRepository couponRepository;
 
-    public ApplyService(CouponRepository couponRepository) {
+    private final CouponCountRepository couponCountRepository;
+
+    public ApplyService(CouponRepository couponRepository, CouponCountRepository couponCountRepository) {
         this.couponRepository = couponRepository;
+        this.couponCountRepository = couponCountRepository;
     }
 
     public void apply(Long userId){
-        long count = couponRepository.count();
+        // redis incr key: value 1씩 증가
+        // redis는 싱글 스레드
+        // redis는 incr는 빠름
+
+        Long count = couponCountRepository.increment();
 
         if (count > 100) {
             return;


### PR DESCRIPTION
<img width="857" height="331" alt="image" src="https://github.com/user-attachments/assets/4c2c6964-47e0-49bf-8cc6-e3aafb20d1b9" />

### 이유
- redis는 싱글 스레드
- 발급 작업이 완료 되기 전까지 다른 쿠폰을 발급 하지 않음
- 따라서 101개 이상 쿠폰이 발급 되지 않음

### 추가적인 문제
- 발급 요청이 많이 들어오면 그후의 다른 요청(조회 등) 처리가 지연된다
- 짧은 시간동안 많은 요청이 들어올때 DB 서버의 부하